### PR TITLE
Abstracted complexity away from plugin initializer.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - "12"
   - "10"
+  - "8"
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 
 node_js:
-  - "9"
-  - "8"
-  - "6"
-  - "4"
+  - "12"
+  - "10"
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ npm i fastify-zipkin --save
 ```
 
 ## Usage
-Require the plugin and register it within Fastify, the pass the following options: `{ tracer [, serviceName] [, port] }`
+Require the plugin and register it within Fastify, the pass the following options: `{ tracer, serviceName [, servicePort] }`
+
 ```js
 const fastify = require('fastify')()
 

--- a/README.md
+++ b/README.md
@@ -14,23 +14,11 @@ Require the plugin and register it within Fastify, the pass the following option
 ```js
 const fastify = require('fastify')()
 
-const { Tracer, BatchRecorder, jsonEncoder: { JSON_V2 } } = require('zipkin')
-const { HttpLogger } = require('zipkin-transport-http')
-const CLSContext = require('zipkin-context-cls')
-
-const zipkinBaseUrl = 'http://localhost:9411'
-const recorder = new BatchRecorder({
-  logger: new HttpLogger({
-    endpoint: `${zipkinBaseUrl}/api/v2/spans`,
-    jsonEncoder: JSON_V2
-  })
+fastify.register(require('fastify-zipkin'), {
+  serviceName: 'my-service-name',
+  servicePort: 3000,
+  zipkinUrl: 'http://localhost:9411'
 })
-
-const ctxImpl = new CLSContext('zipkin')
-const localServiceName = 'service-name'
-const tracer = new Tracer({ ctxImpl, recorder, localServiceName })
-
-fastify.register(require('fastify-zipkin'), { tracer })
 
 fastify.get('/', (req, reply) => {
   reply.send({ hello: 'world' })

--- a/example.js
+++ b/example.js
@@ -1,23 +1,12 @@
 'use strict'
 
 const fastify = require('fastify')()
-const { Tracer, BatchRecorder, jsonEncoder: { JSON_V2 } } = require('zipkin')
-const { HttpLogger } = require('zipkin-transport-http')
-const CLSContext = require('zipkin-context-cls')
 
-const zipkinBaseUrl = 'http://localhost:9411'
-const recorder = new BatchRecorder({
-  logger: new HttpLogger({
-    endpoint: `${zipkinBaseUrl}/api/v2/spans`,
-    jsonEncoder: JSON_V2
-  })
+fastify.register(require('./index'), {
+  serviceName: 'test',
+  servicePort: '3000',
+  zipkinUrl: 'http://localhost:9411'
 })
-
-const ctxImpl = new CLSContext('zipkin')
-const localServiceName = 'fastify'
-const tracer = new Tracer({ ctxImpl, recorder, localServiceName })
-
-fastify.register(require('./index'), { tracer })
 
 fastify.get('/', (req, reply) => {
   reply.send({ hello: 'world' })

--- a/index.js
+++ b/index.js
@@ -85,6 +85,6 @@ function basic404 (req, reply) {
 }
 
 module.exports = fp(zipkinPlugin, {
-  fastify: '>= 2',
+  fastify: '^2.0.0',
   name: 'fastify-zipkin'
 })

--- a/index.js
+++ b/index.js
@@ -4,14 +4,13 @@ const url = require('url')
 const fp = require('fastify-plugin')
 const zipkin = require('zipkin')
 const assert = require('assert')
+const { Tracer, BatchRecorder, jsonEncoder: { JSON_V2 } } = require('zipkin')
+const { HttpLogger } = require('zipkin-transport-http')
+const CLSContext = require('zipkin-context-cls')
 
 const Some = zipkin.option.Some
 const None = zipkin.option.None
 const Instrumentation = zipkin.Instrumentation
-
-const { Tracer, BatchRecorder, jsonEncoder: { JSON_V2 } } = require('zipkin')
-const { HttpLogger } = require('zipkin-transport-http')
-const CLSContext = require('zipkin-context-cls')
 
 function zipkinPlugin (fastify, opts, next) {
   assert(opts.serviceName, 'serviceName option should not be empty')

--- a/index.js
+++ b/index.js
@@ -9,11 +9,12 @@ const Some = zipkin.option.Some
 const None = zipkin.option.None
 const Instrumentation = zipkin.Instrumentation
 
+const { Tracer, BatchRecorder, jsonEncoder: { JSON_V2 } } = require('zipkin')
+const { HttpLogger } = require('zipkin-transport-http')
+const CLSContext = require('zipkin-context-cls')
+
 function zipkinPlugin (fastify, opts, next) {
   assert(opts.serviceName, 'serviceName option should not be empty')
-  const { Tracer, BatchRecorder, jsonEncoder: { JSON_V2 } } = require('zipkin')
-  const { HttpLogger } = require('zipkin-transport-http')
-  const CLSContext = require('zipkin-context-cls')
 
   const recorder = new BatchRecorder({
     logger: new HttpLogger({

--- a/package.json
+++ b/package.json
@@ -22,16 +22,17 @@
   "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
   "license": "MIT",
   "devDependencies": {
-    "fastify": "^0.40.0",
-    "sinon": "^4.2.0",
+    "fastify": "^2.10.0",
+    "node-fetch": "^2.6.0",
+    "sinon": "^7.5.0",
     "standard": "^10.0.3",
-    "tap": "^11.0.1",
-    "zipkin-context-cls": "^0.11.0",
-    "zipkin-transport-http": "^0.11.2"
+    "tap": "^14.10.2",
+    "zipkin": "^0.19.1",
+    "zipkin-context-cls": "^0.19.0",
+    "zipkin-transport-http": "^0.19.1"
   },
   "dependencies": {
-    "fastify-plugin": "^0.2.1",
-    "zipkin": "^0.11.2"
+    "fastify-plugin": "^1.6.0"
   },
   "bugs": {
     "url": "https://github.com/fastify/fastify-zipkin/issues"

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
     "node-fetch": "^2.6.0",
     "sinon": "^7.5.0",
     "standard": "^10.0.3",
-    "tap": "^14.10.2",
+    "tap": "^14.10.2"
+  },
+  "dependencies": {
+    "fastify-plugin": "^1.6.0",
     "zipkin": "^0.19.1",
     "zipkin-context-cls": "^0.19.0",
     "zipkin-transport-http": "^0.19.1"
-  },
-  "dependencies": {
-    "fastify-plugin": "^1.6.0"
   },
   "bugs": {
     "url": "https://github.com/fastify/fastify-zipkin/issues"

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('tap')
 const sinon = require('sinon')
 const Fastify = require('fastify')
 const zipkinPlugin = require('./index')
@@ -43,18 +43,14 @@ test('Should register the hooks and trace the request', t => {
       t.strictEqual(annotations[1].annotation.annotationType, 'Rpc')
       t.strictEqual(annotations[1].annotation.name, 'GET')
       t.strictEqual(annotations[2].annotation.annotationType, 'BinaryAnnotation')
-      t.strictEqual(annotations[2].annotation.key, 'http.url')
+      t.strictEqual(annotations[2].annotation.key, 'http.path')
       t.strictEqual(annotations[2].annotation.value, '/')
       t.strictEqual(annotations[3].annotation.annotationType, 'ServerRecv')
       t.strictEqual(annotations[4].annotation.annotationType, 'LocalAddr')
       t.strictEqual(annotations[5].annotation.annotationType, 'BinaryAnnotation')
-      t.strictEqual(annotations[5].annotation.key, 'X-B3-Flags')
-      t.strictEqual(annotations[5].annotation.value, '1')
-      t.strictEqual(annotations[6].annotation.annotationType, 'BinaryAnnotation')
-      t.strictEqual(annotations[6].annotation.key, 'http.status_code')
-      t.strictEqual(annotations[6].annotation.value, '' + res.statusCode)
-      t.strictEqual(annotations[7].annotation.annotationType, 'ServerSend')
-
+      t.strictEqual(annotations[5].annotation.key, 'http.status_code')
+      t.strictEqual(annotations[5].annotation.value, '201')
+      t.strictEqual(annotations[6].annotation.annotationType, 'ServerSend')
       t.end()
     })
   })
@@ -82,38 +78,6 @@ test('Should register the hooks and trace the request (404)', t => {
       t.strictEqual(annotations[5].annotation.annotationType, 'BinaryAnnotation')
       t.strictEqual(annotations[5].annotation.key, 'http.status_code')
       t.strictEqual(annotations[5].annotation.value, '' + res.statusCode)
-
-      t.end()
-    })
-  })
-})
-
-test('Should handle querystrings', t => {
-  const fastify = Fastify()
-
-  const record = sinon.spy()
-  const recorder = { record }
-  const ctxImpl = new ExplicitContext()
-  const serviceName = 'test'
-  const tracer = new Tracer({ recorder, ctxImpl })
-
-  ctxImpl.scoped(() => {
-    fastify.register(zipkinPlugin, { tracer, serviceName })
-
-    fastify.get('/', (req, reply) => {
-      reply.send({ hello: 'world' })
-    })
-
-    fastify.inject({
-      url: '/?foo=bar',
-      method: 'GET'
-    }, (err, res) => {
-      t.error(err)
-
-      const annotations = record.args.map((args) => args[0])
-      t.strictEqual(annotations[2].annotation.annotationType, 'BinaryAnnotation')
-      t.strictEqual(annotations[2].annotation.key, 'http.url')
-      t.strictEqual(annotations[2].annotation.value, '/?foo=bar')
 
       t.end()
     })

--- a/test.js
+++ b/test.js
@@ -17,10 +17,12 @@ test('Should error when initializing the plugin without serviceName argument', t
   const tracer = new Tracer({ recorder, ctxImpl })
   const zipkinUrl = 'http://0.0.0.0:9441'
 
-  ctxImpl.scoped(() => {
-    t.throws(() => fastify.register(zipkinPlugin, { tracer, zipkinUrl }).after(), {}, 'serviceName option should not be empty')
-    t.end()
-  })
+  t.throws(
+    () => fastify.register(zipkinPlugin, { tracer, zipkinUrl }).after(),
+    {},
+    'serviceName option should not be empty'
+  )
+  t.end()
 })
 
 test('Should error when initializing the plugin without zipkinUrl argument', t => {
@@ -32,10 +34,12 @@ test('Should error when initializing the plugin without zipkinUrl argument', t =
   const tracer = new Tracer({ recorder, ctxImpl })
   const serviceName = 'test'
 
-  ctxImpl.scoped(() => {
-    t.throws(() => fastify.register(zipkinPlugin, { tracer, serviceName }).after(), {}, 'zipkinUrl option should not be empty')
-    t.end()
-  })
+  t.throws(
+    () => fastify.register(zipkinPlugin, { tracer, serviceName }).after(),
+    {},
+    'zipkinUrl option should not be empty'
+  )
+  t.end()
 })
 
 test('Should register the hooks and trace the request', t => {
@@ -56,35 +60,44 @@ test('Should register the hooks and trace the request', t => {
       reply.code(201).send({ hello: 'world' })
     })
 
-    fastify.inject({
-      url: '/',
-      method: 'GET',
-      headers: {
-        'X-B3-TraceId': 'aaa',
-        'X-B3-SpanId': 'bbb',
-        'X-B3-Flags': '1'
-      }
-    }, (err, res) => {
-      t.error(err)
+    fastify.inject(
+      {
+        url: '/',
+        method: 'GET',
+        headers: {
+          'X-B3-TraceId': 'aaa',
+          'X-B3-SpanId': 'bbb',
+          'X-B3-Flags': '1'
+        }
+      },
+      (err, res) => {
+        t.error(err)
 
-      const annotations = record.args.map((args) => args[0])
-      annotations.forEach((ann) => t.strictEqual(ann.traceId.traceId, 'aaa'))
-      annotations.forEach((ann) => t.strictEqual(ann.traceId.spanId, 'bbb'))
-      t.strictEqual(annotations[0].annotation.annotationType, 'ServiceName')
-      t.strictEqual(annotations[0].annotation.serviceName, serviceName)
-      t.strictEqual(annotations[1].annotation.annotationType, 'Rpc')
-      t.strictEqual(annotations[1].annotation.name, 'GET')
-      t.strictEqual(annotations[2].annotation.annotationType, 'BinaryAnnotation')
-      t.strictEqual(annotations[2].annotation.key, 'http.path')
-      t.strictEqual(annotations[2].annotation.value, '/')
-      t.strictEqual(annotations[3].annotation.annotationType, 'ServerRecv')
-      t.strictEqual(annotations[4].annotation.annotationType, 'LocalAddr')
-      t.strictEqual(annotations[5].annotation.annotationType, 'BinaryAnnotation')
-      t.strictEqual(annotations[5].annotation.key, 'http.status_code')
-      t.strictEqual(annotations[5].annotation.value, '201')
-      t.strictEqual(annotations[6].annotation.annotationType, 'ServerSend')
-      t.end()
-    })
+        const annotations = record.args.map(args => args[0])
+        annotations.forEach(ann => t.strictEqual(ann.traceId.traceId, 'aaa'))
+        annotations.forEach(ann => t.strictEqual(ann.traceId.spanId, 'bbb'))
+        t.strictEqual(annotations[0].annotation.annotationType, 'ServiceName')
+        t.strictEqual(annotations[0].annotation.serviceName, serviceName)
+        t.strictEqual(annotations[1].annotation.annotationType, 'Rpc')
+        t.strictEqual(annotations[1].annotation.name, 'GET')
+        t.strictEqual(
+          annotations[2].annotation.annotationType,
+          'BinaryAnnotation'
+        )
+        t.strictEqual(annotations[2].annotation.key, 'http.path')
+        t.strictEqual(annotations[2].annotation.value, '/')
+        t.strictEqual(annotations[3].annotation.annotationType, 'ServerRecv')
+        t.strictEqual(annotations[4].annotation.annotationType, 'LocalAddr')
+        t.strictEqual(
+          annotations[5].annotation.annotationType,
+          'BinaryAnnotation'
+        )
+        t.strictEqual(annotations[5].annotation.key, 'http.status_code')
+        t.strictEqual(annotations[5].annotation.value, '201')
+        t.strictEqual(annotations[6].annotation.annotationType, 'ServerSend')
+        t.end()
+      }
+    )
   })
 })
 
@@ -101,19 +114,25 @@ test('Should register the hooks and trace the request (404)', t => {
   ctxImpl.scoped(() => {
     fastify.register(zipkinPlugin, { tracer, serviceName, zipkinUrl })
 
-    fastify.inject({
-      url: '/404',
-      method: 'GET'
-    }, (err, res) => {
-      t.error(err)
+    fastify.inject(
+      {
+        url: '/404',
+        method: 'GET'
+      },
+      (err, res) => {
+        t.error(err)
 
-      const annotations = record.args.map((args) => args[0])
-      t.strictEqual(annotations[5].annotation.annotationType, 'BinaryAnnotation')
-      t.strictEqual(annotations[5].annotation.key, 'http.status_code')
-      t.strictEqual(annotations[5].annotation.value, '' + res.statusCode)
+        const annotations = record.args.map(args => args[0])
+        t.strictEqual(
+          annotations[5].annotation.annotationType,
+          'BinaryAnnotation'
+        )
+        t.strictEqual(annotations[5].annotation.key, 'http.status_code')
+        t.strictEqual(annotations[5].annotation.value, '' + res.statusCode)
 
-      t.end()
-    })
+        t.end()
+      }
+    )
   })
 })
 
@@ -137,19 +156,22 @@ test('Should record a reasonably accurate span duration', t => {
       }, PAUSE_TIME_MILLIS)
     })
 
-    fastify.inject({
-      url: '/',
-      method: 'GET'
-    }, (err, res) => {
-      t.error(err)
+    fastify.inject(
+      {
+        url: '/',
+        method: 'GET'
+      },
+      (err, res) => {
+        t.error(err)
 
-      const annotations = record.args.map((args) => args[0])
-      const serverRecvTs = annotations[3].timestamp / 1000.0
-      const serverSendTs = annotations[6].timestamp / 1000.0
-      const durationMillis = (serverSendTs - serverRecvTs)
-      t.ok(durationMillis >= PAUSE_TIME_MILLIS)
+        const annotations = record.args.map(args => args[0])
+        const serverRecvTs = annotations[3].timestamp / 1000.0
+        const serverSendTs = annotations[6].timestamp / 1000.0
+        const durationMillis = serverSendTs - serverRecvTs
+        t.ok(durationMillis >= PAUSE_TIME_MILLIS)
 
-      t.end()
-    })
+        t.end()
+      }
+    )
   })
 })


### PR DESCRIPTION
This PR is based on the init branch.

Abstracted specific Zipkin configuration to the plugin itself, the user should only set the service name, and Zipkin URL, however, a tracer is an optional argument the user can also send, whenever the need for a custom tracer is required, like in the tests.

Updated dependencies.

Remove test for Zipkin sending the correct http.url with query params, since support for url was removed for security reasons, and now in exchange for that there is http.path.

Updated tests accordingly to new Zipkin API.


cc @lucamaraschi & @mattcan

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ x] run `npm run test` and `npm run benchmark`
- [ x] tests and/or benchmarks are included
- [ x] documentation is changed or added
- [ x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
