### PR TITLE
chore: migrate from tap to node:test and c8

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,4 +1,0 @@
-timeout: 120
-
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "zipkin": "docker run -p 9411:9411 openzipkin/zipkin",
     "lint": "standard",
     "test": "npm run test:unit && npm run test:typescript",
-    "test:unit": "tap",
+    "test:unit": "c8 --100 node --test",
     "test:typescript": "tsd"
   },
   "repository": {
@@ -28,11 +28,11 @@
   "license": "MIT",
   "devDependencies": {
     "@fastify/pre-commit": "2.1.0",
+    "c8": "^10.1.2",
     "fastify": "^5.0.0",
     "node-fetch": "^2.6.7",
     "sinon": "^18.0.0",
     "standard": "^17.0.0",
-    "tap": "^16.0.0",
     "tsd": "^0.31.0"
   },
   "dependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,12 +1,13 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const sinon = require('sinon')
 const Fastify = require('fastify')
 const zipkinPlugin = require('..')
 const zipkin = require('zipkin')
 const Tracer = zipkin.Tracer
 const ExplicitContext = zipkin.ExplicitContext
+const { setTimeout: sleep } = require('node:timers/promises')
 
 test('Should error when initializing the plugin without serviceName argument', async t => {
   const fastify = Fastify()
@@ -20,7 +21,7 @@ test('Should error when initializing the plugin without serviceName argument', a
   try {
     fastify.register(zipkinPlugin, { tracer, httpReporterUrl })
   } catch (e) {
-    t.equal(e.message, 'serviceName option should not be empty')
+    t.assert.strictEqual(e.message, 'serviceName option should not be empty')
   }
 })
 
@@ -36,11 +37,27 @@ test('Should error when initializing the plugin without httpReporterUrl argument
   try {
     fastify.register(zipkinPlugin, { tracer, serviceName })
   } catch (e) {
-    t.equal(e.message, 'httpReporterUrl option should not be empty')
+    t.assert.strictEqual(e.message, 'httpReporterUrl option should not be empty')
   }
 })
 
-test('Should register the hooks and trace the request', t => {
+test('Should error when initializing the plugin without httpReporterUrl argument', async t => {
+  const fastify = Fastify()
+
+  const record = sinon.spy()
+  const recorder = { record }
+  const ctxImpl = new ExplicitContext()
+  const tracer = new Tracer({ recorder, ctxImpl })
+  const serviceName = 'test'
+
+  try {
+    fastify.register(zipkinPlugin, { tracer, serviceName })
+  } catch (e) {
+    t.assert.equal(e.message, 'httpReporterUrl option should not be empty')
+  }
+})
+
+test('Should register the hooks and trace the request', async t => {
   const fastify = Fastify()
 
   const record = sinon.spy()
@@ -51,55 +68,57 @@ test('Should register the hooks and trace the request', t => {
 
   const tracer = new Tracer({ recorder, ctxImpl })
 
-  ctxImpl.scoped(() => {
-    fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
+  await new Promise((resolve) => {
+    ctxImpl.scoped(() => {
+      fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
 
-    fastify.get('/', (req, reply) => {
-      reply.code(201).send({ hello: 'world' })
-    })
+      fastify.get('/', (req, reply) => {
+        reply.code(201).send({ hello: 'world' })
+      })
 
-    fastify.inject(
-      {
-        url: '/',
-        method: 'GET',
-        headers: {
-          'X-B3-TraceId': 'aaa',
-          'X-B3-SpanId': 'bbb',
-          'X-B3-Flags': '1'
+      fastify.inject(
+        {
+          url: '/',
+          method: 'GET',
+          headers: {
+            'X-B3-TraceId': 'aaa',
+            'X-B3-SpanId': 'bbb',
+            'X-B3-Flags': '1'
+          }
+        },
+        (err, res) => {
+          t.assert.ifError(err)
+
+          const annotations = record.args.map(args => args[0])
+          annotations.forEach(ann => t.assert.strictEqual(ann.traceId.traceId, 'aaa'))
+          annotations.forEach(ann => t.assert.strictEqual(ann.traceId.spanId, 'bbb'))
+          t.assert.strictEqual(annotations[0].annotation.annotationType, 'ServiceName')
+          t.assert.strictEqual(annotations[0].annotation.serviceName, serviceName)
+          t.assert.strictEqual(annotations[1].annotation.annotationType, 'Rpc')
+          t.assert.strictEqual(annotations[1].annotation.name, 'GET')
+          t.assert.strictEqual(
+            annotations[2].annotation.annotationType,
+            'BinaryAnnotation'
+          )
+          t.assert.strictEqual(annotations[2].annotation.key, 'http.path')
+          t.assert.strictEqual(annotations[2].annotation.value, '/')
+          t.assert.strictEqual(annotations[3].annotation.annotationType, 'ServerRecv')
+          t.assert.strictEqual(annotations[4].annotation.annotationType, 'LocalAddr')
+          t.assert.strictEqual(
+            annotations[5].annotation.annotationType,
+            'BinaryAnnotation'
+          )
+          t.assert.strictEqual(annotations[5].annotation.key, 'http.status_code')
+          t.assert.strictEqual(annotations[5].annotation.value, '201')
+          t.assert.strictEqual(annotations[6].annotation.annotationType, 'ServerSend')
+          resolve()
         }
-      },
-      (err, res) => {
-        t.error(err)
-
-        const annotations = record.args.map(args => args[0])
-        annotations.forEach(ann => t.equal(ann.traceId.traceId, 'aaa'))
-        annotations.forEach(ann => t.equal(ann.traceId.spanId, 'bbb'))
-        t.equal(annotations[0].annotation.annotationType, 'ServiceName')
-        t.equal(annotations[0].annotation.serviceName, serviceName)
-        t.equal(annotations[1].annotation.annotationType, 'Rpc')
-        t.equal(annotations[1].annotation.name, 'GET')
-        t.equal(
-          annotations[2].annotation.annotationType,
-          'BinaryAnnotation'
-        )
-        t.equal(annotations[2].annotation.key, 'http.path')
-        t.equal(annotations[2].annotation.value, '/')
-        t.equal(annotations[3].annotation.annotationType, 'ServerRecv')
-        t.equal(annotations[4].annotation.annotationType, 'LocalAddr')
-        t.equal(
-          annotations[5].annotation.annotationType,
-          'BinaryAnnotation'
-        )
-        t.equal(annotations[5].annotation.key, 'http.status_code')
-        t.equal(annotations[5].annotation.value, '201')
-        t.equal(annotations[6].annotation.annotationType, 'ServerSend')
-        t.end()
-      }
-    )
+      )
+    })
   })
 })
 
-test('Should register the hooks and trace the request (404)', t => {
+test('Should register the hooks and trace the request (404)', async t => {
   const fastify = Fastify()
 
   const record = sinon.spy()
@@ -109,32 +128,34 @@ test('Should register the hooks and trace the request (404)', t => {
   const tracer = new Tracer({ recorder, ctxImpl })
   const httpReporterUrl = 'http://0.0.0.0:9441/api/v2/spans'
 
-  ctxImpl.scoped(() => {
-    fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
+  await new Promise((resolve) => {
+    ctxImpl.scoped(async () => {
+      await fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
 
-    fastify.inject(
-      {
-        url: '/404',
-        method: 'GET'
-      },
-      (err, res) => {
-        t.error(err)
+      fastify.inject(
+        {
+          url: '/404',
+          method: 'GET'
+        },
+        (err, res) => {
+          t.assert.ifError(err)
 
-        const annotations = record.args.map(args => args[0])
-        t.equal(
-          annotations[5].annotation.annotationType,
-          'BinaryAnnotation'
-        )
-        t.equal(annotations[5].annotation.key, 'http.status_code')
-        t.equal(annotations[5].annotation.value, '' + res.statusCode)
+          const annotations = record.args.map(args => args[0])
+          t.assert.strictEqual(
+            annotations[5].annotation.annotationType,
+            'BinaryAnnotation'
+          )
+          t.assert.strictEqual(annotations[5].annotation.key, 'http.status_code')
+          t.assert.strictEqual(annotations[5].annotation.value, '' + res.statusCode)
 
-        t.end()
-      }
-    )
+          resolve()
+        }
+      )
+    })
   })
 })
 
-test('Should record a reasonably accurate span duration', t => {
+test('Should record a reasonably accurate span duration', async t => {
   const fastify = Fastify()
 
   const record = sinon.spy()
@@ -145,37 +166,39 @@ test('Should record a reasonably accurate span duration', t => {
   const tracer = new Tracer({ recorder, ctxImpl })
   const PAUSE_TIME_MILLIS = 100
 
-  ctxImpl.scoped(() => {
-    fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
+  await new Promise((resolve) => {
+    ctxImpl.scoped(async () => {
+      await fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
 
-    fastify.get('/', (req, reply) => {
-      setTimeout(() => {
+      fastify.get('/', async (req, reply) => {
+        await sleep(PAUSE_TIME_MILLIS)
         reply.send({ hello: 'world' })
-      }, PAUSE_TIME_MILLIS)
+      })
+
+      fastify.inject(
+        {
+          url: '/',
+          method: 'GET'
+        },
+        (err, res) => {
+          t.assert.ifError(err)
+
+          const annotations = record.args.map(args => args[0])
+          const serverRecvTs = annotations[3].timestamp / 1000.0
+          const serverSendTs = annotations[6].timestamp / 1000.0
+          const durationMillis = serverSendTs - serverRecvTs
+          t.assert.ok(durationMillis >= PAUSE_TIME_MILLIS)
+
+          resolve()
+        }
+      )
     })
-
-    fastify.inject(
-      {
-        url: '/',
-        method: 'GET'
-      },
-      (err, res) => {
-        t.error(err)
-
-        const annotations = record.args.map(args => args[0])
-        const serverRecvTs = annotations[3].timestamp / 1000.0
-        const serverSendTs = annotations[6].timestamp / 1000.0
-        const durationMillis = serverSendTs - serverRecvTs
-        t.ok(durationMillis >= PAUSE_TIME_MILLIS)
-
-        t.end()
-      }
-    )
   })
 })
 
-test('Should record a reasonably accurate span duration with custom recorder', t => {
+test('Should record a reasonably accurate span duration with custom recorder', async t => {
   const fastify = Fastify()
+  fastify.setNotFoundHandler(() => {})
 
   const record = sinon.spy()
   const recorder = { record }
@@ -184,31 +207,32 @@ test('Should record a reasonably accurate span duration with custom recorder', t
   const httpReporterUrl = 'http://0.0.0.0:9441/api/v2/spans'
   const PAUSE_TIME_MILLIS = 100
 
-  ctxImpl.scoped(() => {
-    fastify.register(zipkinPlugin, { recorder, serviceName, httpReporterUrl })
+  await new Promise((resolve) => {
+    ctxImpl.scoped(async () => {
+      await fastify.register(zipkinPlugin, { recorder, serviceName, httpReporterUrl })
 
-    fastify.get('/', (req, reply) => {
-      setTimeout(() => {
+      fastify.get('/', async (req, reply) => {
+        await sleep(PAUSE_TIME_MILLIS)
         reply.send({ hello: 'world' })
-      }, PAUSE_TIME_MILLIS)
+      })
+
+      fastify.inject(
+        {
+          url: '/',
+          method: 'GET'
+        },
+        (err, res) => {
+          t.assert.ifError(err)
+
+          const annotations = record.args.map(args => args[0])
+          const serverRecvTs = annotations[3].timestamp / 1000.0
+          const serverSendTs = annotations[6].timestamp / 1000.0
+          const durationMillis = serverSendTs - serverRecvTs
+          t.assert.ok(durationMillis >= PAUSE_TIME_MILLIS)
+
+          resolve()
+        }
+      )
     })
-
-    fastify.inject(
-      {
-        url: '/',
-        method: 'GET'
-      },
-      (err, res) => {
-        t.error(err)
-
-        const annotations = record.args.map(args => args[0])
-        const serverRecvTs = annotations[3].timestamp / 1000.0
-        const serverSendTs = annotations[6].timestamp / 1000.0
-        const durationMillis = serverSendTs - serverRecvTs
-        t.ok(durationMillis >= PAUSE_TIME_MILLIS)
-
-        t.end()
-      }
-    )
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,9 +7,8 @@ const zipkinPlugin = require('..')
 const zipkin = require('zipkin')
 const Tracer = zipkin.Tracer
 const ExplicitContext = zipkin.ExplicitContext
-const { setTimeout: sleep } = require('node:timers/promises')
 
-test('Should error when initializing the plugin without serviceName argument', async t => {
+test('Should error when initializing the plugin without serviceName argument', t => {
   const fastify = Fastify()
 
   const record = sinon.spy()
@@ -25,7 +24,7 @@ test('Should error when initializing the plugin without serviceName argument', a
   }
 })
 
-test('Should error when initializing the plugin without httpReporterUrl argument', async t => {
+test('Should error when initializing the plugin without httpReporterUrl argument', t => {
   const fastify = Fastify()
 
   const record = sinon.spy()
@@ -41,7 +40,7 @@ test('Should error when initializing the plugin without httpReporterUrl argument
   }
 })
 
-test('Should error when initializing the plugin without httpReporterUrl argument', async t => {
+test('Should error when initializing the plugin without httpReporterUrl argument', t => {
   const fastify = Fastify()
 
   const record = sinon.spy()
@@ -57,7 +56,7 @@ test('Should error when initializing the plugin without httpReporterUrl argument
   }
 })
 
-test('Should register the hooks and trace the request', async t => {
+test('Should register the hooks and trace the request', t => {
   const fastify = Fastify()
 
   const record = sinon.spy()
@@ -68,57 +67,54 @@ test('Should register the hooks and trace the request', async t => {
 
   const tracer = new Tracer({ recorder, ctxImpl })
 
-  await new Promise((resolve) => {
-    ctxImpl.scoped(() => {
-      fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
+  ctxImpl.scoped(() => {
+    fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
 
-      fastify.get('/', (req, reply) => {
-        reply.code(201).send({ hello: 'world' })
-      })
-
-      fastify.inject(
-        {
-          url: '/',
-          method: 'GET',
-          headers: {
-            'X-B3-TraceId': 'aaa',
-            'X-B3-SpanId': 'bbb',
-            'X-B3-Flags': '1'
-          }
-        },
-        (err, res) => {
-          t.assert.ifError(err)
-
-          const annotations = record.args.map(args => args[0])
-          annotations.forEach(ann => t.assert.strictEqual(ann.traceId.traceId, 'aaa'))
-          annotations.forEach(ann => t.assert.strictEqual(ann.traceId.spanId, 'bbb'))
-          t.assert.strictEqual(annotations[0].annotation.annotationType, 'ServiceName')
-          t.assert.strictEqual(annotations[0].annotation.serviceName, serviceName)
-          t.assert.strictEqual(annotations[1].annotation.annotationType, 'Rpc')
-          t.assert.strictEqual(annotations[1].annotation.name, 'GET')
-          t.assert.strictEqual(
-            annotations[2].annotation.annotationType,
-            'BinaryAnnotation'
-          )
-          t.assert.strictEqual(annotations[2].annotation.key, 'http.path')
-          t.assert.strictEqual(annotations[2].annotation.value, '/')
-          t.assert.strictEqual(annotations[3].annotation.annotationType, 'ServerRecv')
-          t.assert.strictEqual(annotations[4].annotation.annotationType, 'LocalAddr')
-          t.assert.strictEqual(
-            annotations[5].annotation.annotationType,
-            'BinaryAnnotation'
-          )
-          t.assert.strictEqual(annotations[5].annotation.key, 'http.status_code')
-          t.assert.strictEqual(annotations[5].annotation.value, '201')
-          t.assert.strictEqual(annotations[6].annotation.annotationType, 'ServerSend')
-          resolve()
-        }
-      )
+    fastify.get('/', (req, reply) => {
+      reply.code(201).send({ hello: 'world' })
     })
+
+    fastify.inject(
+      {
+        url: '/',
+        method: 'GET',
+        headers: {
+          'X-B3-TraceId': 'aaa',
+          'X-B3-SpanId': 'bbb',
+          'X-B3-Flags': '1'
+        }
+      },
+      (err, res) => {
+        t.assert.ifError(err)
+
+        const annotations = record.args.map(args => args[0])
+        annotations.forEach(ann => t.assert.strictEqual(ann.traceId.traceId, 'aaa'))
+        annotations.forEach(ann => t.assert.strictEqual(ann.traceId.spanId, 'bbb'))
+        t.assert.strictEqual(annotations[0].annotation.annotationType, 'ServiceName')
+        t.assert.strictEqual(annotations[0].annotation.serviceName, serviceName)
+        t.assert.strictEqual(annotations[1].annotation.annotationType, 'Rpc')
+        t.assert.strictEqual(annotations[1].annotation.name, 'GET')
+        t.assert.strictEqual(
+          annotations[2].annotation.annotationType,
+          'BinaryAnnotation'
+        )
+        t.assert.strictEqual(annotations[2].annotation.key, 'http.path')
+        t.assert.strictEqual(annotations[2].annotation.value, '/')
+        t.assert.strictEqual(annotations[3].annotation.annotationType, 'ServerRecv')
+        t.assert.strictEqual(annotations[4].annotation.annotationType, 'LocalAddr')
+        t.assert.strictEqual(
+          annotations[5].annotation.annotationType,
+          'BinaryAnnotation'
+        )
+        t.assert.strictEqual(annotations[5].annotation.key, 'http.status_code')
+        t.assert.strictEqual(annotations[5].annotation.value, '201')
+        t.assert.strictEqual(annotations[6].annotation.annotationType, 'ServerSend')
+      }
+    )
   })
 })
 
-test('Should register the hooks and trace the request (404)', async t => {
+test('Should register the hooks and trace the request (404)', t => {
   const fastify = Fastify()
 
   const record = sinon.spy()
@@ -128,34 +124,30 @@ test('Should register the hooks and trace the request (404)', async t => {
   const tracer = new Tracer({ recorder, ctxImpl })
   const httpReporterUrl = 'http://0.0.0.0:9441/api/v2/spans'
 
-  await new Promise((resolve) => {
-    ctxImpl.scoped(async () => {
-      await fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
+  ctxImpl.scoped(() => {
+    fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
 
-      fastify.inject(
-        {
-          url: '/404',
-          method: 'GET'
-        },
-        (err, res) => {
-          t.assert.ifError(err)
+    fastify.inject(
+      {
+        url: '/404',
+        method: 'GET'
+      },
+      (err, res) => {
+        t.assert.ifError(err)
 
-          const annotations = record.args.map(args => args[0])
-          t.assert.strictEqual(
-            annotations[5].annotation.annotationType,
-            'BinaryAnnotation'
-          )
-          t.assert.strictEqual(annotations[5].annotation.key, 'http.status_code')
-          t.assert.strictEqual(annotations[5].annotation.value, '' + res.statusCode)
-
-          resolve()
-        }
-      )
-    })
+        const annotations = record.args.map(args => args[0])
+        t.assert.strictEqual(
+          annotations[5].annotation.annotationType,
+          'BinaryAnnotation'
+        )
+        t.assert.strictEqual(annotations[5].annotation.key, 'http.status_code')
+        t.assert.strictEqual(annotations[5].annotation.value, '' + res.statusCode)
+      }
+    )
   })
 })
 
-test('Should record a reasonably accurate span duration', async t => {
+test('Should record a reasonably accurate span duration', t => {
   const fastify = Fastify()
 
   const record = sinon.spy()
@@ -166,37 +158,105 @@ test('Should record a reasonably accurate span duration', async t => {
   const tracer = new Tracer({ recorder, ctxImpl })
   const PAUSE_TIME_MILLIS = 100
 
-  await new Promise((resolve) => {
-    ctxImpl.scoped(async () => {
-      await fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
+  ctxImpl.scoped(() => {
+    fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
 
-      fastify.get('/', async (req, reply) => {
-        await sleep(PAUSE_TIME_MILLIS)
+    fastify.get('/', (req, reply) => {
+      setTimeout(() => {
         reply.send({ hello: 'world' })
-      })
-
-      fastify.inject(
-        {
-          url: '/',
-          method: 'GET'
-        },
-        (err, res) => {
-          t.assert.ifError(err)
-
-          const annotations = record.args.map(args => args[0])
-          const serverRecvTs = annotations[3].timestamp / 1000.0
-          const serverSendTs = annotations[6].timestamp / 1000.0
-          const durationMillis = serverSendTs - serverRecvTs
-          t.assert.ok(durationMillis >= PAUSE_TIME_MILLIS)
-
-          resolve()
-        }
-      )
+      }, PAUSE_TIME_MILLIS)
     })
+
+    fastify.inject(
+      {
+        url: '/',
+        method: 'GET'
+      },
+      (err, res) => {
+        t.assert.ifError(err)
+
+        const annotations = record.args.map(args => args[0])
+        const serverRecvTs = annotations[3].timestamp / 1000.0
+        const serverSendTs = annotations[6].timestamp / 1000.0
+        const durationMillis = serverSendTs - serverRecvTs
+        t.assert.ok(durationMillis >= PAUSE_TIME_MILLIS)
+      }
+    )
   })
 })
 
-test('Should record a reasonably accurate span duration with custom recorder', async t => {
+test('Should register the hooks and trace the request (404)', t => {
+  const fastify = Fastify()
+
+  const record = sinon.spy()
+  const recorder = { record }
+  const ctxImpl = new ExplicitContext()
+  const serviceName = 'test'
+  const tracer = new Tracer({ recorder, ctxImpl })
+  const httpReporterUrl = 'http://0.0.0.0:9441/api/v2/spans'
+
+  ctxImpl.scoped(() => {
+    fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
+
+    fastify.inject(
+      {
+        url: '/404',
+        method: 'GET'
+      },
+      (err, res) => {
+        t.assert.ifError(err)
+
+        const annotations = record.args.map(args => args[0])
+        t.assert.strictEqual(
+          annotations[5].annotation.annotationType,
+          'BinaryAnnotation'
+        )
+        t.assert.strictEqual(annotations[5].annotation.key, 'http.status_code')
+        t.assert.strictEqual(annotations[5].annotation.value, '' + res.statusCode)
+      }
+    )
+  })
+})
+
+test('Should record a reasonably accurate span duration', t => {
+  const fastify = Fastify()
+
+  const record = sinon.spy()
+  const recorder = { record }
+  const ctxImpl = new ExplicitContext()
+  const serviceName = 'test'
+  const httpReporterUrl = 'http://0.0.0.0:9441/api/v2/spans'
+  const tracer = new Tracer({ recorder, ctxImpl })
+  const PAUSE_TIME_MILLIS = 100
+
+  ctxImpl.scoped(() => {
+    fastify.register(zipkinPlugin, { tracer, serviceName, httpReporterUrl })
+
+    fastify.get('/', (req, reply) => {
+      setTimeout(() => {
+        reply.send({ hello: 'world' })
+      }, PAUSE_TIME_MILLIS)
+    })
+
+    fastify.inject(
+      {
+        url: '/',
+        method: 'GET'
+      },
+      (err, res) => {
+        t.assert.ifError(err)
+
+        const annotations = record.args.map(args => args[0])
+        const serverRecvTs = annotations[3].timestamp / 1000.0
+        const serverSendTs = annotations[6].timestamp / 1000.0
+        const durationMillis = serverSendTs - serverRecvTs
+        t.assert.ok(durationMillis >= PAUSE_TIME_MILLIS)
+      }
+    )
+  })
+})
+
+test('Should record a reasonably accurate span duration with custom recorder', t => {
   const fastify = Fastify()
   fastify.setNotFoundHandler(() => {})
 
@@ -207,32 +267,29 @@ test('Should record a reasonably accurate span duration with custom recorder', a
   const httpReporterUrl = 'http://0.0.0.0:9441/api/v2/spans'
   const PAUSE_TIME_MILLIS = 100
 
-  await new Promise((resolve) => {
-    ctxImpl.scoped(async () => {
-      await fastify.register(zipkinPlugin, { recorder, serviceName, httpReporterUrl })
+  ctxImpl.scoped(() => {
+    fastify.register(zipkinPlugin, { recorder, serviceName, httpReporterUrl })
 
-      fastify.get('/', async (req, reply) => {
-        await sleep(PAUSE_TIME_MILLIS)
+    fastify.get('/', (req, reply) => {
+      setTimeout(() => {
         reply.send({ hello: 'world' })
-      })
-
-      fastify.inject(
-        {
-          url: '/',
-          method: 'GET'
-        },
-        (err, res) => {
-          t.assert.ifError(err)
-
-          const annotations = record.args.map(args => args[0])
-          const serverRecvTs = annotations[3].timestamp / 1000.0
-          const serverSendTs = annotations[6].timestamp / 1000.0
-          const durationMillis = serverSendTs - serverRecvTs
-          t.assert.ok(durationMillis >= PAUSE_TIME_MILLIS)
-
-          resolve()
-        }
-      )
+      }, PAUSE_TIME_MILLIS)
     })
+
+    fastify.inject(
+      {
+        url: '/',
+        method: 'GET'
+      },
+      (err, res) => {
+        t.assert.ifError(err)
+
+        const annotations = record.args.map(args => args[0])
+        const serverRecvTs = annotations[3].timestamp / 1000.0
+        const serverSendTs = annotations[6].timestamp / 1000.0
+        const durationMillis = serverSendTs - serverRecvTs
+        t.assert.ok(durationMillis >= PAUSE_TIME_MILLIS)
+      }
+    )
   })
 })


### PR DESCRIPTION
#### Checklist

This PR migrates from from `tap` to `node:test` and `c8`

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
