### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "2.2.0",
     "c8": "^10.1.2",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.12.0",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.