### PR TITLE
refactor(types): migrate from tsd to tstyche

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
     "test:unit": "c8 --100 node --test",
-    "test:typescript": "tsd",
+    "test:typescript": "tstyche",
     "zipkin": "docker run -p 9411:9411 openzipkin/zipkin"
   },
   "repository": {
@@ -54,7 +54,7 @@
     "neostandard": "^0.13.0",
     "node-fetch": "^2.6.7",
     "sinon": "^21.0.0",
-    "tsd": "^0.33.0"
+    "tstyche": "^7.0.0"
   },
   "dependencies": {
     "fastify-plugin": "^5.0.0",

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -1,13 +1,18 @@
 import Fastify from 'fastify'
-import { expectError } from 'tsd'
+import { expect } from 'tstyche'
 import { ConsoleRecorder, ExplicitContext, Tracer } from 'zipkin'
 import zipkinPlugin from '..'
 
 const fastify = Fastify()
 
-expectError(fastify.register(zipkinPlugin, { httpReporterUrl: 'a' }))
-expectError(fastify.register(zipkinPlugin, { serviceName: 'a' }))
-expectError(fastify.register(zipkinPlugin, { serviceName: 1, httpReporterUrl: '' }))
+expect(fastify.register).type.not.toBeCallableWith(zipkinPlugin, {
+  httpReporterUrl: 'a'
+})
+expect(fastify.register).type.not.toBeCallableWith(zipkinPlugin, { serviceName: 'a' })
+expect(fastify.register).type.not.toBeCallableWith(zipkinPlugin, {
+  serviceName: 1,
+  httpReporterUrl: ''
+})
 
 fastify.register(zipkinPlugin, { serviceName: 'test', httpReporterUrl: 'http://' })
 fastify.register(zipkinPlugin, { serviceName: 'test', httpReporterUrl: 'http://', servicePort: 0 })


### PR DESCRIPTION
Proposal:

- migrate from `tsd` to `tstyche`

PR of Reference: 
  - https://github.com/fastify/fastify/pull/6532
  - https://github.com/fastify/fastify/pull/6525
